### PR TITLE
Fixed multisite issues and limited export to subscriber role only

### DIFF
--- a/class.php
+++ b/class.php
@@ -60,6 +60,14 @@ if ( ! class_exists( 'Leaky_Paywall_Reporting_tool' ) ) {
 	                        $custom_meta_fields = $dl_pluginissuem_leaky_paywall_subscriber_meta->get_settings();
 						}
 
+						global $blog_id;
+						if ( is_multisite_premium() && !is_main_site( $blog_id ) ){
+							$site = '_' . $blog_id;
+						} else {
+							$site = '';
+						}
+
+
 						if ( !empty( $users ) ) {
 							global $is_leaky_paywall, $which_leaky_paywall, $no_lp_subscribers;
 							$no_lp_subscribers = false;
@@ -70,12 +78,15 @@ if ( ! class_exists( 'Leaky_Paywall_Reporting_tool' ) ) {
 								$user_meta[$user->ID]['user_login'] = $user->data->user_login;
 								$user_meta[$user->ID]['user_email'] = $user->data->user_email;
 								foreach( $meta as $key ) {
-									$user_meta[$user->ID][$key] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_' . $key, true );
+									$user_meta[$user->ID][$key] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_' . $key . $site, true );
 								}
 								if ( !empty( $custom_meta_fields['meta_keys'] ) ) {
+
 									foreach( $custom_meta_fields['meta_keys'] as $meta_key ) {
-										$user_meta[$user->ID][$meta_key['name']] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ), true );
+										$user_meta[$user->ID][$meta_key['name']] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ) . $site, true );
 									}
+
+									echo $which_leaky_paywall . '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ) . $site . "<br>";
 								}
 							}
 

--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,9 @@ if ( !function_exists( 'leaky_paywall_reporting_tool_query' ) ){
 
 		if ( !empty( $post ) ) {
 
-			$args = array();
+			$args = array(
+				'role'	=> 'subscriber'
+			);
 
 			$settings = get_leaky_paywall_settings();
 			$mode = 'off' === $settings['test_mode'] ? 'live' : 'test';

--- a/leaky-paywall-reporting-tool.php
+++ b/leaky-paywall-reporting-tool.php
@@ -11,7 +11,7 @@ Plugin Name: Leaky Paywall - Reporting Tool
 Plugin URI: http://zeen101.com/
 Description: A premium WordPress plugin by zeen101.
 Author: zeen101 Development Team
-Version: 1.2.2
+Version: 1.2.3
 Author URI: http://zeen101.com/
 Tags:
 */
@@ -22,7 +22,7 @@ if ( !defined( 'ZEEN101_STORE_URL' ) )
 
 define( 'LP_RT_NAME', 		'Leaky Paywall - Reporting Tool' );
 define( 'LP_RT_SLUG', 		'lp-reporting-tool' );
-define( 'LP_RT_VERSION', 	'1.2.2' );
+define( 'LP_RT_VERSION', 	'1.2.3' );
 define( 'LP_RT_DB_VERSION', '1.0.0' );
 define( 'LP_RT_URL', 		plugin_dir_url( __FILE__ ) );
 define( 'LP_RT_PATH', 		plugin_dir_path( __FILE__ ) );

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,10 @@ A premium WordPress plugin by zeen101 for Leaky Paywall. Adds the ability to exp
 
 ## Changelog
 
+**1.2.3**
+* Fixed multisite export bug
+* Export now only exports users of the subscriber role
+
 **1.2.2**
 * Fix export metadata bug
 


### PR DESCRIPTION
Couple of small fixes here:

- Limited the export to subscriber role only - administrators were being reported on in addition to plain subscribers so limiting the export addresses this issue.
- Reporting on multisite wasn't exporting user meta with the Site ID appended - ID is now appended on all non-main blogs
- Version & readme bump

Let me know any Qs!