### PR TITLE
Double-prefix user meta fix

### DIFF
--- a/class.php
+++ b/class.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Leaky_Paywall_Reporting_tool' ) ) {
 
 
 						if ( !empty( $users ) ) {
-							global $is_leaky_paywall, $which_leaky_paywall, $no_lp_subscribers;
+							global $is_leaky_paywall, $no_lp_subscribers;
 							$no_lp_subscribers = false;
 
 							$user_meta = array();
@@ -83,7 +83,7 @@ if ( ! class_exists( 'Leaky_Paywall_Reporting_tool' ) ) {
 								if ( !empty( $custom_meta_fields['meta_keys'] ) ) {
 
 									foreach( $custom_meta_fields['meta_keys'] as $meta_key ) {
-										$user_meta[$user->ID][$meta_key['name']] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ) . $site, true );
+										$user_meta[$user->ID][$meta_key['name']] = get_leaky_user_meta( $user->ID, '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ) . $site );
 									}
 								}
 							}

--- a/class.php
+++ b/class.php
@@ -78,15 +78,13 @@ if ( ! class_exists( 'Leaky_Paywall_Reporting_tool' ) ) {
 								$user_meta[$user->ID]['user_login'] = $user->data->user_login;
 								$user_meta[$user->ID]['user_email'] = $user->data->user_email;
 								foreach( $meta as $key ) {
-									$user_meta[$user->ID][$key] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_' . $key . $site, true );
+									$user_meta[$user->ID][$key] = get_leaky_user_meta( $user->ID, '_leaky_paywall_' . $mode . '_' . $key . $site );
 								}
 								if ( !empty( $custom_meta_fields['meta_keys'] ) ) {
 
 									foreach( $custom_meta_fields['meta_keys'] as $meta_key ) {
 										$user_meta[$user->ID][$meta_key['name']] = get_user_meta( $user->ID, $which_leaky_paywall . '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ) . $site, true );
 									}
-
-									echo $which_leaky_paywall . '_leaky_paywall_' . $mode . '_subscriber_meta_' . sanitize_title_with_dashes( $meta_key['name'] ) . $site . "<br>";
 								}
 							}
 

--- a/functions.php
+++ b/functions.php
@@ -145,18 +145,20 @@ if ( !function_exists( 'leaky_paywall_reporting_tool_csv_export_file' ) ) {
 	}
 }
 
-function get_leaky_user_meta( $user_id, $key ){
-	global $which_leaky_paywall;
+if ( !function_exists( 'get_leaky_user_meta' ) ) {
+	function get_leaky_user_meta( $user_id, $key ){
+		global $which_leaky_paywall;
 
-	// Try for the new meta string first
-	$meta = get_user_meta( $user_id, $which_leaky_paywall . $key, true );
+		// Try for the new meta string first
+		$meta = get_user_meta( $user_id, $which_leaky_paywall . $key, true );
 
-	// If that returned nothing, try for an un-prefixed meta string
-	if ( empty( $meta ) ){
-		$meta = get_user_meta( $user_id, $key, true );
+		// If that returned nothing, try for an un-prefixed meta string
+		if ( empty( $meta ) ){
+			$meta = get_user_meta( $user_id, $key, true );
+		}
+
+		// Return whichever result returned, if any
+		return $meta;
+
 	}
-
-	// Return whichever result returned, if any
-	return $meta;
-
 }

--- a/functions.php
+++ b/functions.php
@@ -144,3 +144,19 @@ if ( !function_exists( 'leaky_paywall_reporting_tool_csv_export_file' ) ) {
 
 	}
 }
+
+function get_leaky_user_meta( $user_id, $key ){
+	global $which_leaky_paywall;
+
+	// Try for the new meta string first
+	$meta = get_user_meta( $user_id, $which_leaky_paywall . $key, true );
+
+	// If that returned nothing, try for an un-prefixed meta string
+	if ( empty( $meta ) ){
+		$meta = get_user_meta( $user_id, $key, true );
+	}
+
+	// Return whichever result returned, if any
+	return $meta;
+
+}

--- a/functions.php
+++ b/functions.php
@@ -145,6 +145,21 @@ if ( !function_exists( 'leaky_paywall_reporting_tool_csv_export_file' ) ) {
 	}
 }
 
+/**
+ * Get user meta, attempting with and without the `_issuem` prefix.
+ *
+ * There was a period where several plugins were setting user meta information
+ * without the _issuem prefix due to a bad check. This function compensates
+ * for this inconsistency by first attempting to grab user meta values with the
+ * $which_leaky_paywall prefix and if none exists, trying for an unprefixed version.
+ *
+ * @see get_user_meta
+ * @global string $which_leaky_paywall user meta prefix
+ *
+ * @param int $user_id User ID.
+ * @param string $key Desired main key string without prefix.
+ * @return string Meta value.
+ */
 if ( !function_exists( 'get_leaky_user_meta' ) ) {
 	function get_leaky_user_meta( $user_id, $key ){
 		global $which_leaky_paywall;

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ A premium WordPress plugin by zeen101 for Leaky Paywall. Adds the ability to exp
 **1.2.3**
 * Fixed multisite export bug
 * Export now only exports users of the subscriber role
+* Retrieves and exports meta with and without the `_issuem` prefix
 
 **1.2.2**
 * Fix export metadata bug


### PR DESCRIPTION
Added the function `get_leaky_user_meta()` that checks for both prefixed and unprefixed user meta and attempts to return either one, starting with prefixed since prefixed *should* be more current. 

Did not bump version this time since it's rolled up with the other changes.